### PR TITLE
Console ID Abuse System

### DIFF
--- a/nas_server.py
+++ b/nas_server.py
@@ -162,7 +162,14 @@ class NasHTTPServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                             "retry": "1",
                             "reason": "User's console is banned."
                         }
-#Comment the lines below to disable console registration
+                    elif self.server.db.console_abuse(post):
+                        logger.log(logging.DEBUG, "Login denied - Console is banned due to abuse of identifiers"+str(post))
+                        ret = {
+                            "datetime": time.strftime("%Y%m%d%H%M%S"),
+                            "returncd": "3915",
+                            "locator": "gamespy.com",
+                            "retry": "1",
+                        }
                     elif not self.server.db.pending(post):
                         logger.log(logging.DEBUG, "Login denied - Unknown console"+str(post))
                         ret = {


### PR DESCRIPTION
Swapped out MAC prefix whitelist with console ID abuse system

About the abuse system:
- Error code assigned: 23915 - Banned: Abuse use of a console identifier
- A console cannot have more than 1 MAC assigned to it
- This mitigates MAC changer code from being used

Also in this PR:
- Automatic console activation was introduced to provide a seamless login. The line for it can be commented out to go back to the old system.